### PR TITLE
Test pinning coverage-reporter version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           file: coverage.lcov
           fail-on-error: false
+          coverage-reporter-version: v0.6.14
 
   sam-build-and-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Test pinning the coverage-reporter version used by coveralls to work around an issue in the latest version.
